### PR TITLE
Volumes used to remain after running test consuming disk space.

### DIFF
--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -71,7 +71,7 @@ def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]
         )
     finally:
         docker_client.kill(container=container["Id"])
-        docker_client.remove_container(container["Id"])
+        docker_client.remove_container(container["Id"], v=True, force=True)
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Force=True just for being 100% sure. Sometimes I found running containers after a run, but not sure why they remained live