### PR TITLE
start postgres in UTC timezone

### DIFF
--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -43,7 +43,7 @@ def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]
         host_config=docker_client.create_host_config(
             port_bindings={5432: (LOCALHOST, unused_port)}, tmpfs=[postgresql_data_path]
         ),
-        environment={"POSTGRES_HOST_AUTH_METHOD": "trust", "PGDATA": postgresql_data_path},
+        environment={"POSTGRES_HOST_AUTH_METHOD": "trust", "PGDATA": postgresql_data_path, "TZ": "UTC", "PYTZ": "UTC"},
         command="-c fsync=off -c full_page_writes=off -c synchronous_commit=off -c bgwriter_lru_maxpages=0 -c jit=off",
     )
 


### PR DESCRIPTION
Without `TZ` and `PGTZ` in environment postgres container starts with local timezone. This results in tests ambiguity between local run and GHA run, for example, if test checks json repr of `datetime`

https://www.postgresql.org/docs/current/libpq-envars.html