### PR TITLE
Override docker host with env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.17 (2024-04-03)
+
+* Override docker host with env variable
+
+
 ## v0.0.15 (2023-05-04)
 
 * Pin version of `urllib3` ([see for more details](https://github.com/docker/docker-py/issues/3113))

--- a/pytest_pg/__init__.py
+++ b/pytest_pg/__init__.py
@@ -7,7 +7,7 @@ from .fixtures import PG, pg, pg_11, pg_12, pg_13, pg_14, pg_15, pg_16, run_pg  
 
 __all__: Tuple[str, ...] = ("PG", "run_pg", "pg", "pg_11", "pg_12", "pg_13", "pg_14", "pg_15", "pg_16")
 
-__version__ = "0.0.16"
+__version__ = "0.0.17"
 
 version = f"{__version__}, Python {sys.version}"
 

--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -10,7 +10,6 @@ import pytest
 from .utils import find_unused_local_port, is_pg_ready
 
 LOCALHOST = "127.0.0.1"
-DOCKER_BASE_URL = os.getenv("DOCKER_HOST", None)
 DEFAULT_PG_USER = "postgres"
 DEFAULT_PG_PASSWORD = "mysecretpassword"
 DEFAULT_PG_DATABASE = "postgres"
@@ -27,7 +26,7 @@ class PG:
 
 @contextlib.contextmanager
 def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]:
-    docker_client = docker.APIClient(base_url=DOCKER_BASE_URL, version="auto")
+    docker_client = docker.APIClient(base_url=os.getenv("DOCKER_HOST"), version="auto")
 
     docker_client.pull(image)
 

--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -1,9 +1,10 @@
 import contextlib
 import dataclasses
+import os
 import time
 import uuid
 from typing import Generator
-import os
+
 import docker
 import pytest
 

--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -3,14 +3,14 @@ import dataclasses
 import time
 import uuid
 from typing import Generator
-
+import os
 import docker
 import pytest
 
 from .utils import find_unused_local_port, is_pg_ready
 
 LOCALHOST = "127.0.0.1"
-
+DOCKER_BASE_URL = os.getenv("DOCKER_HOST", None)
 DEFAULT_PG_USER = "postgres"
 DEFAULT_PG_PASSWORD = "mysecretpassword"
 DEFAULT_PG_DATABASE = "postgres"
@@ -27,7 +27,7 @@ class PG:
 
 @contextlib.contextmanager
 def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]:
-    docker_client = docker.APIClient(version="auto")
+    docker_client = docker.APIClient(base_url=DOCKER_BASE_URL, version="auto")
 
     docker_client.pull(image)
 


### PR DESCRIPTION
Docker url can be different if we use something like lima + `docker context`. This url is not discoverable by defaul, bu we can use env variable to pass it.

It will work with something like 

```
DOCKER_HOST=unix:///Users/slivtime/.lima/docker/sock/docker.sock
```