### PR TITLE
Update urllib3 version constraint to allow up to 3.0.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -7,5 +7,5 @@ wheel==0.43.0
 twine==5.0.0
 docker==7.0.0
 mypy==1.9.0
-urllib3>=1.26.0,<2.0.0
+urllib3>=1.26.0,<3.0.0
 requests<2.32.0

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from pathlib import Path
 from setuptools import setup
 
 install_requires = [
-    "docker>=5.0.0",
+    "docker>=6.1.0",
     "pytest>=6.0.0",
     "urllib3>=1.26.0,<3.0.0",
     "requests<2.32.0",

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup
 install_requires = [
     "docker>=5.0.0",
     "pytest>=6.0.0",
-    "urllib3>=1.26.0,<2.0.0",
+    "urllib3>=1.26.0,<3.0.0",
     "requests<2.32.0",
 ]
 


### PR DESCRIPTION
The bug with **urllib3** 2.0 was fixed in **docker-py** 6.1.0:
https://github.com/docker/docker-py/pull/3116
https://github.com/docker/docker-py/releases/tag/6.1.0