### PR TITLE
Feat: Resolve DOCKER_HOST from active docker context

### DIFF
--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -1,6 +1,5 @@
 import contextlib
 import dataclasses
-import os
 import time
 import uuid
 from typing import Generator
@@ -9,7 +8,7 @@ import docker
 import docker.errors
 import pytest
 
-from .utils import find_unused_local_port, is_pg_ready
+from .utils import find_unused_local_port, is_pg_ready, resolve_docker_host
 
 LOCALHOST = "127.0.0.1"
 DEFAULT_PG_USER = "postgres"
@@ -28,7 +27,7 @@ class PG:
 
 @contextlib.contextmanager
 def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]:
-    docker_client = docker.APIClient(base_url=os.getenv("DOCKER_HOST"), version="auto")
+    docker_client = docker.APIClient(base_url=resolve_docker_host(), version="auto")
     try:
         docker_client.inspect_image(image)
     except docker.errors.ImageNotFound:

--- a/pytest_pg/utils.py
+++ b/pytest_pg/utils.py
@@ -1,5 +1,8 @@
 import asyncio
+import os
+import shutil
 import socket
+import subprocess
 from typing import Any, Optional, Protocol
 
 
@@ -90,3 +93,26 @@ def find_unused_local_port() -> int:
     with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
         s.bind(("127.0.0.1", 0))
         return s.getsockname()[1]  # type: ignore
+
+
+def resolve_docker_host() -> Optional[str]:
+    # The `docker` Python SDK doesn't read `docker context` like the CLI does.
+    # Hand DOCKER_HOST to it from the active context so non-default setups
+    # (Colima, custom contexts) work without the user exporting it manually.
+    # No-op when the docker CLI is missing or DOCKER_HOST is already set.
+    host = os.environ.get("DOCKER_HOST")
+    if host:
+        return host
+    if shutil.which("docker") is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}"],
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return result.stdout.strip() or None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,60 @@
+import subprocess
+from typing import Any
+from unittest import mock
+
+from pytest_pg.utils import resolve_docker_host
+
+
+def test_resolve_docker_host_returns_env_when_set(monkeypatch: Any) -> None:
+    monkeypatch.setenv("DOCKER_HOST", "tcp://example:2375")
+    with mock.patch("pytest_pg.utils.subprocess.run") as run:
+        assert resolve_docker_host() == "tcp://example:2375"
+    run.assert_not_called()
+
+
+def test_resolve_docker_host_returns_none_when_cli_missing(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    with mock.patch("pytest_pg.utils.shutil.which", return_value=None):
+        assert resolve_docker_host() is None
+
+
+def test_resolve_docker_host_reads_active_context(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="unix:///tmp/colima.sock\n", stderr="")
+    with (
+        mock.patch("pytest_pg.utils.shutil.which", return_value="/usr/bin/docker"),
+        mock.patch("pytest_pg.utils.subprocess.run", return_value=completed) as run,
+    ):
+        assert resolve_docker_host() == "unix:///tmp/colima.sock"
+    args, _ = run.call_args
+    assert args[0] == ["docker", "context", "inspect", "--format", "{{.Endpoints.docker.Host}}"]
+
+
+def test_resolve_docker_host_returns_none_on_empty_output(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    completed = subprocess.CompletedProcess(args=[], returncode=0, stdout="\n", stderr="")
+    with (
+        mock.patch("pytest_pg.utils.shutil.which", return_value="/usr/bin/docker"),
+        mock.patch("pytest_pg.utils.subprocess.run", return_value=completed),
+    ):
+        assert resolve_docker_host() is None
+
+
+def test_resolve_docker_host_returns_none_on_cli_error(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    err = subprocess.CalledProcessError(returncode=1, cmd=["docker"])
+    with (
+        mock.patch("pytest_pg.utils.shutil.which", return_value="/usr/bin/docker"),
+        mock.patch("pytest_pg.utils.subprocess.run", side_effect=err),
+    ):
+        assert resolve_docker_host() is None
+
+
+def test_resolve_docker_host_returns_none_on_timeout(monkeypatch: Any) -> None:
+    monkeypatch.delenv("DOCKER_HOST", raising=False)
+    err = subprocess.TimeoutExpired(cmd=["docker"], timeout=5)
+    with (
+        mock.patch("pytest_pg.utils.shutil.which", return_value="/usr/bin/docker"),
+        mock.patch("pytest_pg.utils.subprocess.run", side_effect=err),
+    ):
+        assert resolve_docker_host() is None


### PR DESCRIPTION
## Summary
The `docker` Python SDK doesn't read `docker context` like the CLI does, so non-default setups (Colima, custom contexts) require users to manually export `DOCKER_HOST`. This PR resolves it automatically from the active context.

## Changes
- `pytest_pg/utils.py`: new `resolve_docker_host()` helper. Returns `DOCKER_HOST` env if set; otherwise runs `docker context inspect --format '{{.Endpoints.docker.Host}}'` to read the active context's host. Returns `None` when the docker CLI is missing or the call fails/times out.
- `pytest_pg/fixtures.py`: `run_pg` now passes `resolve_docker_host()` to `docker.APIClient(base_url=...)` instead of `os.getenv("DOCKER_HOST")`.
- `tests/test_utils.py`: 6 unit tests covering env-set, CLI-missing, active-context read, empty output, CLI error, timeout.

## Behavior
- `DOCKER_HOST` set → returned as-is (no CLI call).
- `DOCKER_HOST` unset, docker CLI present → resolves from active context.
- `DOCKER_HOST` unset, docker CLI missing or failing → returns `None` (preserves prior behavior, SDK uses its defaults).