### PR TITLE
Reduce PG container startup time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v0.0.28 (2026-05-06)
+
+* [Reduce PostgreSQL container startup time](https://github.com/anna-money/pytest-pg/pull/230)
+
+
 ## v0.0.27 (2026-05-01)
 
 * [Resolve DOCKER_HOST from docker context](https://github.com/anna-money/pytest-pg/pull/228)

--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -45,7 +45,11 @@ def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]
         host_config=docker_client.create_host_config(
             port_bindings={5432: (LOCALHOST, unused_port)}, tmpfs=[postgresql_data_path]
         ),
-        environment={"POSTGRES_HOST_AUTH_METHOD": "trust", "PGDATA": postgresql_data_path},
+        environment={
+            "POSTGRES_HOST_AUTH_METHOD": "trust",
+            "PGDATA": postgresql_data_path,
+            "POSTGRES_INITDB_ARGS": "--no-sync",
+        },
         command="-c fsync=off -c full_page_writes=off -c synchronous_commit=off -c bgwriter_lru_maxpages=0 -c jit=off",
     )
 
@@ -64,7 +68,7 @@ def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]
             ):
                 break
 
-            time.sleep(0.5)
+            time.sleep(0.05)
         else:
             container_logs = docker_client.logs(container["Id"]).decode()
             pytest.fail(f"Failed to start postgres using {image} in {ready_timeout} seconds: {container_logs}")

--- a/pytest_pg/utils.py
+++ b/pytest_pg/utils.py
@@ -25,7 +25,7 @@ def _try_get_is_postgres_ready_based_on_psycopg2() -> IsReadyFunc | None:
 
         def _is_postgres_ready(**params: Any) -> bool:
             try:
-                with psycopg2.connect(**params):
+                with psycopg2.connect(**params, connect_timeout=5):
                     return True
             except psycopg2.OperationalError:
                 return False
@@ -42,7 +42,7 @@ def _try_get_is_postgres_ready_based_on_psycopg3() -> IsReadyFunc | None:
         def _is_postgres_ready(**params: Any) -> bool:
             try:
                 params.pop("database")
-                with psycopg.connect(**params):
+                with psycopg.connect(**params, connect_timeout=5):
                     return True
             except psycopg.OperationalError:
                 return False
@@ -60,7 +60,7 @@ def _try_get_is_postgres_ready_based_on_asyncpg() -> IsReadyFunc | None:
         def _is_postgres_ready(**params: Any) -> bool:
             async def _is_postgres_ready_async() -> bool:
                 try:
-                    connection = await asyncpg.connect(**params)
+                    connection = await asyncpg.connect(**params, timeout=5.0)
                     await connection.close()
                     return True
                 except (asyncpg.exceptions.PostgresError, OSError):


### PR DESCRIPTION
## Summary
- Skip the post-initdb fsync sweep via `POSTGRES_INITDB_ARGS=--no-sync` (~100-300ms saved per fixture, risk-free since `PGDATA` is on tmpfs).
- Tighten readiness-probe sleep granularity from 500ms to 50ms — eliminates up to ~450ms of dead time after PG becomes ready.
- Add explicit connection timeouts to all three readiness probes:
  - asyncpg: `timeout=5.0` (was relying on the 60s default)
  - psycopg2 / psycopg3: `connect_timeout=5` (libpq integer seconds; default is 0 = no limit, which can hang the probe loop on a half-initialized server even if TCP is already accepting)

Aggregate effect on the nine-fixture run in `tests/test_pg.py`: roughly a few seconds shaved on warm Docker; larger gains where any single probe would otherwise hit a libpq stall.

## Test plan
- [ ] CI matrix green (Python 3.10-3.14 × pytest 8.0-9.0)
- [ ] \`make lint\` clean locally
- [ ] \`uv run pytest -vv tests/test_utils.py\` passes (6/6)
- [ ] \`uv run pytest -vv tests/test_pg.py\` against live Docker

🤖 Generated with [Claude Code](https://claude.com/claude-code)