### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-*    @Pliner @fedorfo @spaceorc @roman-annamoney
-
+*    @anna-money/backend


### PR DESCRIPTION
## Summary
Replace per-user owners in `.github/CODEOWNERS` with the `@anna-money/backend` team to match the convention used in sibling repos (e.g. `aio-request`).

## Test plan
- [ ] GitHub recognizes `@anna-money/backend` as the code owner on subsequent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)