### PR TITLE
Add pg_docker_image_name option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+* Configurable base image via the `pg_docker_image_name` ini option (set in `pyproject.toml`)
+* Removed `pg_11`, `pg_12`, `pg_13` fixtures — PostgreSQL 11/12/13 are end-of-life
+
+
 ## v0.0.28 (2026-05-06)
 
 * [Reduce PostgreSQL container startup time](https://github.com/anna-money/pytest-pg/pull/230)

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A pytest plugin that provides session-scoped fixtures for running PostgreSQL inside Docker containers.
 It automatically spins up a container, waits for PostgreSQL to become ready, exposes connection details
 (`host`, `port`, `user`, `password`, `database`) via a `PG` dataclass, and tears the container down after
-the test session. Pre-built fixtures are available for PostgreSQL versions 11 through 18 as well as `latest`.
+the test session. Pre-built fixtures are available for PostgreSQL versions 14 through 18 as well as `latest`.
 
 Readiness checks work with any of the common drivers — asyncpg, psycopg2, or psycopg3.
 
@@ -22,9 +22,6 @@ To speed up tests, pytest-pg does the following tweaks:
 You can use the following fixtures:
 
 * `pg` – the latest PostgreSQL image available
-* `pg_11` – PostgreSQL 11
-* `pg_12` – PostgreSQL 12
-* `pg_13` – PostgreSQL 13
 * `pg_14` – PostgreSQL 14
 * `pg_15` – PostgreSQL 15
 * `pg_16` – PostgreSQL 16
@@ -84,4 +81,18 @@ def postgres_env_vars(pg_18: pytest_pg.PG) -> Generator[None]:
     os.environ['POSTGRES_PORT'] = str(pg_18.port)
     os.environ['POSTGRES_DBNAME'] = pg_18.database
     yield
+```
+
+
+# Using a custom registry
+
+By default the built-in fixtures pull `postgres:<version>` from Docker Hub. To pull from a mirror
+instead (for example, to avoid Docker Hub rate limits), set the base image in `pyproject.toml`. The
+fixtures append the version tag to it, so the mirror must carry the matching tags: `<base>:14` …
+`<base>:18` for the versioned fixtures, and `<base>:latest` for the `pg` fixture. Mirrors of pinned
+versions often omit `latest`; if yours does, use a versioned `pg_NN` fixture instead of `pg`.
+
+```toml
+[tool.pytest.ini_options]
+pg_docker_image_name = "eu.gcr.io/anna-money/postgres"
 ```

--- a/pytest_pg/__init__.py
+++ b/pytest_pg/__init__.py
@@ -1,14 +1,13 @@
 from importlib.metadata import version as _get_version
 
-from .fixtures import PG, pg, pg_11, pg_12, pg_13, pg_14, pg_15, pg_16, pg_17, pg_18, run_pg
+import pytest
+
+from .fixtures import PG, pg, pg_14, pg_15, pg_16, pg_17, pg_18, run_pg
 
 __all__: tuple[str, ...] = (
     "PG",
     "run_pg",
     "pg",
-    "pg_11",
-    "pg_12",
-    "pg_13",
     "pg_14",
     "pg_15",
     "pg_16",
@@ -17,3 +16,11 @@ __all__: tuple[str, ...] = (
 )
 
 __version__ = _get_version("pytest_pg")
+
+
+def pytest_addoption(parser: pytest.Parser) -> None:
+    parser.addini(
+        "pg_docker_image_name",
+        help="Base PostgreSQL image (registry and name, without tag); the version tag is appended.",
+        default="postgres",
+    )

--- a/pytest_pg/fixtures.py
+++ b/pytest_pg/fixtures.py
@@ -8,7 +8,7 @@ import docker
 import docker.errors
 import pytest
 
-from .utils import find_unused_local_port, is_pg_ready, resolve_docker_host
+from .utils import find_unused_local_port, is_pg_ready, resolve_docker_host, resolve_image
 
 LOCALHOST = "127.0.0.1"
 DEFAULT_PG_USER = "postgres"
@@ -86,54 +86,36 @@ def run_pg(image: str, ready_timeout: float = 30.0) -> Generator[PG, None, None]
 
 
 @pytest.fixture(scope="session")
-def pg() -> Generator[PG, None, None]:
-    with run_pg("postgres:latest") as pg:
+def pg(pytestconfig: pytest.Config) -> Generator[PG, None, None]:
+    with run_pg(resolve_image(str(pytestconfig.getini("pg_docker_image_name")), "latest")) as pg:
         yield pg
 
 
 @pytest.fixture(scope="session")
-def pg_11() -> Generator[PG, None, None]:
-    with run_pg("postgres:11") as pg:
+def pg_14(pytestconfig: pytest.Config) -> Generator[PG, None, None]:
+    with run_pg(resolve_image(str(pytestconfig.getini("pg_docker_image_name")), "14")) as pg:
         yield pg
 
 
 @pytest.fixture(scope="session")
-def pg_12() -> Generator[PG, None, None]:
-    with run_pg("postgres:12") as pg:
+def pg_15(pytestconfig: pytest.Config) -> Generator[PG, None, None]:
+    with run_pg(resolve_image(str(pytestconfig.getini("pg_docker_image_name")), "15")) as pg:
         yield pg
 
 
 @pytest.fixture(scope="session")
-def pg_13() -> Generator[PG, None, None]:
-    with run_pg("postgres:13") as pg:
+def pg_16(pytestconfig: pytest.Config) -> Generator[PG, None, None]:
+    with run_pg(resolve_image(str(pytestconfig.getini("pg_docker_image_name")), "16")) as pg:
         yield pg
 
 
 @pytest.fixture(scope="session")
-def pg_14() -> Generator[PG, None, None]:
-    with run_pg("postgres:14") as pg:
+def pg_17(pytestconfig: pytest.Config) -> Generator[PG, None, None]:
+    with run_pg(resolve_image(str(pytestconfig.getini("pg_docker_image_name")), "17")) as pg:
         yield pg
 
 
 @pytest.fixture(scope="session")
-def pg_15() -> Generator[PG, None, None]:
-    with run_pg("postgres:15") as pg:
-        yield pg
-
-
-@pytest.fixture(scope="session")
-def pg_16() -> Generator[PG, None, None]:
-    with run_pg("postgres:16") as pg:
-        yield pg
-
-
-@pytest.fixture(scope="session")
-def pg_17() -> Generator[PG, None, None]:
-    with run_pg("postgres:17") as pg:
-        yield pg
-
-
-@pytest.fixture(scope="session")
-def pg_18() -> Generator[PG, None, None]:
-    with run_pg("postgres:18") as pg:
+def pg_18(pytestconfig: pytest.Config) -> Generator[PG, None, None]:
+    with run_pg(resolve_image(str(pytestconfig.getini("pg_docker_image_name")), "18")) as pg:
         yield pg

--- a/pytest_pg/utils.py
+++ b/pytest_pg/utils.py
@@ -116,3 +116,7 @@ def resolve_docker_host() -> str | None:
     except (OSError, subprocess.SubprocessError):
         return None
     return result.stdout.strip() or None
+
+
+def resolve_image(name: str, version: str) -> str:
+    return f"{name}:{version}"

--- a/tests/test_pg.py
+++ b/tests/test_pg.py
@@ -5,18 +5,6 @@ def test_pg(pg: pytest_pg.PG) -> None:
     assert pg
 
 
-def test_pg_11(pg_11: pytest_pg.PG) -> None:
-    assert pg_11
-
-
-def test_pg_12(pg_12: pytest_pg.PG) -> None:
-    assert pg_12
-
-
-def test_pg_13(pg_13: pytest_pg.PG) -> None:
-    assert pg_13
-
-
 def test_pg_14(pg_14: pytest_pg.PG) -> None:
     assert pg_14
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,7 @@ import subprocess
 from typing import Any
 from unittest import mock
 
-from pytest_pg.utils import resolve_docker_host
+from pytest_pg.utils import resolve_docker_host, resolve_image
 
 
 def test_resolve_docker_host_returns_env_when_set(monkeypatch: Any) -> None:
@@ -58,3 +58,11 @@ def test_resolve_docker_host_returns_none_on_timeout(monkeypatch: Any) -> None:
         mock.patch("pytest_pg.utils.subprocess.run", side_effect=err),
     ):
         assert resolve_docker_host() is None
+
+
+def test_resolve_image_uses_default_base() -> None:
+    assert resolve_image("postgres", "14") == "postgres:14"
+
+
+def test_resolve_image_uses_configured_base() -> None:
+    assert resolve_image("eu.gcr.io/anna-money/postgres", "14") == "eu.gcr.io/anna-money/postgres:14"


### PR DESCRIPTION
## What

- **Configurable base image** for the built-in fixtures via the `pg_docker_image_name` pytest ini option, set in `pyproject.toml` `[tool.pytest.ini_options]` (default `postgres`). Fixtures append the version tag, so the resolved image is `<pg_docker_image_name>:<version>`.
- **Drop `pg_11`/`pg_12`/`pg_13`** fixtures — PostgreSQL 11/12/13 are end-of-life.

## Why

Default behaviour is unchanged (`postgres:<version>` from Docker Hub). Consumers on private CI runners that hit Docker Hub rate limits can point the fixtures at an internal mirror without touching fixture usage:

```toml
[tool.pytest.ini_options]
pg_docker_image_name = "eu.gcr.io/anna-money/postgres"
```

(The mirror must carry the matching tags — `<base>:14` … `<base>:18`, and `<base>:latest` for the `pg` fixture; documented in the README.)

## Verification

- `make lint MODE=ci` — ruff + pyright clean.
- `make test` — 14 passed (fixtures `pg`, `pg_14`…`pg_18` spin up real containers; `resolve_image` unit tests cover default + configured base).
- `pg_docker_image_name` shows in `pytest --help`; confirmed an ini value flows through to the actual `docker pull` target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)